### PR TITLE
Fix for jmockit version 1.5 and higher. Class mockit.Mockit does not exi...

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse-jmockit-assist
 Bundle-SymbolicName: eclipse-jmockit-assist;singleton:=true
-Bundle-Version: 0.9.0
+Bundle-Version: 0.9.1
 Bundle-Activator: jmockit.assist.Activator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.jdt.core,

--- a/src/jmockit/assist/JunitLaunchListener.java
+++ b/src/jmockit/assist/JunitLaunchListener.java
@@ -153,7 +153,10 @@ final class JunitLaunchListener implements ILaunchesListener2
 		IJavaModel javaModel = JavaCore.create(ResourcesPlugin.getWorkspace().getRoot());
 		IJavaProject jproj = javaModel.getJavaProject(project);
 
-		IType mockitType = jproj.findType("mockit.Mockit");
+		IType mockitType = jproj.findType("mockit.Mock");
+		if (mockitType == null) {
+		  mockitType = jproj.findType("mockit.Mockit");
+		}
 
 		if (mockitType != null)
 		{


### PR DESCRIPTION
Hello ajermakovics

It's me again. We use now JMockit 1.7 and recognized that it needs a fix on the eclipse plugin. The class mockit.Mockit was removed with 1.5. So it is not suitable anymore to find the location of jmockit.jar. I was quite conservative to just another model lookup. Maybe it would be enougth to change Mockit into Mock. But I am not absolutely sure if older versions would still work.

Hope you can accept my pull request and build a new version for workplace. We really like the plugin.

Kind regards
Roman
