### PR TITLE
Make Compatible with Eclipse 3.6

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -4,16 +4,16 @@ Bundle-Name: Eclipse-jmockit-assist
 Bundle-SymbolicName: eclipse-jmockit-assist;singleton:=true
 Bundle-Version: 0.9.1
 Bundle-Activator: jmockit.assist.Activator
-Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.jdt.core,
  org.eclipse.jdt.ui,
  org.eclipse.jface.text,
- org.eclipse.ui;bundle-version="3.7.0",
- org.eclipse.debug.core;bundle-version="3.7.0",
- org.eclipse.jdt.junit;bundle-version="3.7.0",
+ org.eclipse.ui;bundle-version="3.6.0",
+ org.eclipse.debug.core;bundle-version="3.6.0",
+ org.eclipse.jdt.junit;bundle-version="3.6.0",
  org.eclipse.core.variables,
- org.eclipse.ui.workbench.texteditor;bundle-version="3.7.0",
- org.eclipse.ui.editors;bundle-version="3.7.0"
+ org.eclipse.ui.workbench.texteditor;bundle-version="3.6.0",
+ org.eclipse.ui.editors;bundle-version="3.6.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: Andrejs Jermakovics


### PR DESCRIPTION
I suspected that the plug-in would be compatible with 3.6 since there should be minor changes between 3.6 and 3.7. The purpose of this is so that it can be used with Helios (3.6), and thereby be installable from the marketplace with IBM Rational Application Developer Version 8.5.x which is based on Helios.

IBM's JDK does not play nice with JMockit, and needs the help of this plug-in for the tests to run from the IDE. I have tested the above changes with stand-alone Helios 3.6 and with IBM Rational Application Developer 8.5.5.1. Both worked without any problems. So, it seems that the code-base is perfectly backward compatible with Helios.
