### PR TITLE
Fix for JMockit v1.5+: Problem "Mocked real method not found in type"

### DIFF
--- a/src/jmockit/assist/JMockitCompilationParticipant.java
+++ b/src/jmockit/assist/JMockitCompilationParticipant.java
@@ -137,7 +137,10 @@ public final class JMockitCompilationParticipant extends CompilationParticipant
 		IType mockitType = null;
 		try
 		{
-			mockitType = project.findType(MockUtil.MOCKIT);
+			mockitType = project.findType(MockUtil.MOCK);
+			if (mockitType == null) {
+				mockitType = project.findType(MockUtil.MOCKIT);
+			}
 		}
 		catch (JavaModelException e)
 		{

--- a/src/jmockit/assist/JunitLaunchListener.java
+++ b/src/jmockit/assist/JunitLaunchListener.java
@@ -153,9 +153,9 @@ final class JunitLaunchListener implements ILaunchesListener2
 		IJavaModel javaModel = JavaCore.create(ResourcesPlugin.getWorkspace().getRoot());
 		IJavaProject jproj = javaModel.getJavaProject(project);
 
-		IType mockitType = jproj.findType("mockit.Mock");
+		IType mockitType = jproj.findType(MockUtil.MOCK);
 		if (mockitType == null) {
-		  mockitType = jproj.findType("mockit.Mockit");
+		  mockitType = jproj.findType(MockUtil.MOCKIT);
 		}
 
 		if (mockitType != null)


### PR DESCRIPTION
was not added to CompilationUnit.
(Class mockit.Mockit does not exist anymore.)