### PR TITLE
Issue #23: $clinit() produced 'real method not found' error-marker

### DIFF
--- a/src/jmockit/assist/MockASTVisitor.java
+++ b/src/jmockit/assist/MockASTVisitor.java
@@ -85,12 +85,12 @@ public final class MockASTVisitor extends ASTVisitor
 				{
 					addMarker(node.getName(), "Mocked method missing @Mock annotation", false);
 				}
-	
+
 				if (hasMockAnn && !methodExists )
 				{
 					addMarker(node.getName(), "Mocked real method not found in type", true);
 				}
-	
+
 				if (hasMockAnn && methodExists && isPrivate(meth.getModifiers()))
 				{
 					addMarker(node.getName(), "Mocked method should not be private", true);
@@ -100,7 +100,7 @@ public final class MockASTVisitor extends ASTVisitor
 
 		return true;
 	}
-	
+
 	public IMethodBinding findRealMethod(final MethodDeclaration node,
 			final IMethodBinding meth, final ITypeBinding mockedType)
 	{

--- a/src/jmockit/assist/MockASTVisitor.java
+++ b/src/jmockit/assist/MockASTVisitor.java
@@ -74,27 +74,23 @@ public final class MockASTVisitor extends ASTVisitor
 
 		if ( mockedType != null )
 		{
+			boolean hasMockAnn = MockUtil.isMockMethod(meth);
 			boolean isClassInitMock = MockUtil.isClassInitializerMock(meth);
-
-			if (!isClassInitMock)
-			{		
-				boolean hasMockAnn = MockUtil.isMockMethod(meth);
-				boolean methodExists = findRealMethod(node, meth, mockedType) != null;
+			boolean methodExists = isClassInitMock || findRealMethod(node, meth, mockedType) != null;
 	
-				if (!hasMockAnn && methodExists )
-				{
-					addMarker(node.getName(), "Mocked method missing @Mock annotation", false);
-				}
+			if (!hasMockAnn && methodExists )
+			{
+				addMarker(node.getName(), "Mocked method missing @Mock annotation", false);
+			}
 
-				if (hasMockAnn && !methodExists )
-				{
-					addMarker(node.getName(), "Mocked real method not found in type", true);
-				}
+			if (hasMockAnn && !methodExists )
+			{
+				addMarker(node.getName(), "Mocked real method not found in type", true);
+			}
 
-				if (hasMockAnn && methodExists && isPrivate(meth.getModifiers()))
-				{
-					addMarker(node.getName(), "Mocked method should not be private", true);
-				}
+			if (hasMockAnn && methodExists && isPrivate(meth.getModifiers()))
+			{
+				addMarker(node.getName(), "Mocked method should not be private", true);
 			}
 		}
 

--- a/src/jmockit/assist/MockASTVisitor.java
+++ b/src/jmockit/assist/MockASTVisitor.java
@@ -74,28 +74,33 @@ public final class MockASTVisitor extends ASTVisitor
 
 		if ( mockedType != null )
 		{
-			boolean hasMockAnn = MockUtil.isMockMethod(meth);
-			boolean methodExists = findRealMethod(node, meth, mockedType) != null;
+			boolean isClassInitMock = MockUtil.isClassInitializerMock(meth);
 
-			if (!hasMockAnn && methodExists )
-			{
-				addMarker(node.getName(), "Mocked method missing @Mock annotation", false);
-			}
-
-			if (hasMockAnn && !methodExists )
-			{
-				addMarker(node.getName(), "Mocked real method not found in type", true);
-			}
-
-			if (hasMockAnn && methodExists && isPrivate(meth.getModifiers()))
-			{
-				addMarker(node.getName(), "Mocked method should not be private", true);
+			if (!isClassInitMock)
+			{		
+				boolean hasMockAnn = MockUtil.isMockMethod(meth);
+				boolean methodExists = findRealMethod(node, meth, mockedType) != null;
+	
+				if (!hasMockAnn && methodExists )
+				{
+					addMarker(node.getName(), "Mocked method missing @Mock annotation", false);
+				}
+	
+				if (hasMockAnn && !methodExists )
+				{
+					addMarker(node.getName(), "Mocked real method not found in type", true);
+				}
+	
+				if (hasMockAnn && methodExists && isPrivate(meth.getModifiers()))
+				{
+					addMarker(node.getName(), "Mocked method should not be private", true);
+				}
 			}
 		}
 
 		return true;
 	}
-
+	
 	public IMethodBinding findRealMethod(final MethodDeclaration node,
 			final IMethodBinding meth, final ITypeBinding mockedType)
 	{

--- a/src/jmockit/assist/MockASTVisitor.java
+++ b/src/jmockit/assist/MockASTVisitor.java
@@ -74,27 +74,23 @@ public final class MockASTVisitor extends ASTVisitor
 
 		if ( mockedType != null )
 		{
+			boolean hasMockAnn = MockUtil.isMockMethod(meth);
 			boolean isClassInitMock = MockUtil.isClassInitializerMock(meth);
+			boolean methodExists = isClassInitMock || findRealMethod(node, meth, mockedType) != null;
 
-			if (!isClassInitMock)
-			{		
-				boolean hasMockAnn = MockUtil.isMockMethod(meth);
-				boolean methodExists = findRealMethod(node, meth, mockedType) != null;
-	
-				if (!hasMockAnn && methodExists )
-				{
-					addMarker(node.getName(), "Mocked method missing @Mock annotation", false);
-				}
+			if (!hasMockAnn && methodExists )
+			{
+				addMarker(node.getName(), "Mocked method missing @Mock annotation", false);
+			}
 
-				if (hasMockAnn && !methodExists )
-				{
-					addMarker(node.getName(), "Mocked real method not found in type", true);
-				}
+			if (hasMockAnn && !methodExists )
+			{
+				addMarker(node.getName(), "Mocked real method not found in type", true);
+			}
 
-				if (hasMockAnn && methodExists && isPrivate(meth.getModifiers()))
-				{
-					addMarker(node.getName(), "Mocked method should not be private", true);
-				}
+			if (hasMockAnn && methodExists && isPrivate(meth.getModifiers()))
+			{
+				addMarker(node.getName(), "Mocked method should not be private", true);
 			}
 		}
 

--- a/src/jmockit/assist/MockASTVisitor.java
+++ b/src/jmockit/assist/MockASTVisitor.java
@@ -74,23 +74,27 @@ public final class MockASTVisitor extends ASTVisitor
 
 		if ( mockedType != null )
 		{
-			boolean hasMockAnn = MockUtil.isMockMethod(meth);
 			boolean isClassInitMock = MockUtil.isClassInitializerMock(meth);
-			boolean methodExists = isClassInitMock || findRealMethod(node, meth, mockedType) != null;
 
-			if (!hasMockAnn && methodExists )
-			{
-				addMarker(node.getName(), "Mocked method missing @Mock annotation", false);
-			}
+			if (!isClassInitMock)
+			{		
+				boolean hasMockAnn = MockUtil.isMockMethod(meth);
+				boolean methodExists = findRealMethod(node, meth, mockedType) != null;
+	
+				if (!hasMockAnn && methodExists )
+				{
+					addMarker(node.getName(), "Mocked method missing @Mock annotation", false);
+				}
 
-			if (hasMockAnn && !methodExists )
-			{
-				addMarker(node.getName(), "Mocked real method not found in type", true);
-			}
+				if (hasMockAnn && !methodExists )
+				{
+					addMarker(node.getName(), "Mocked real method not found in type", true);
+				}
 
-			if (hasMockAnn && methodExists && isPrivate(meth.getModifiers()))
-			{
-				addMarker(node.getName(), "Mocked method should not be private", true);
+				if (hasMockAnn && methodExists && isPrivate(meth.getModifiers()))
+				{
+					addMarker(node.getName(), "Mocked method should not be private", true);
+				}
 			}
 		}
 

--- a/src/jmockit/assist/MockUtil.java
+++ b/src/jmockit/assist/MockUtil.java
@@ -30,8 +30,19 @@ public class MockUtil
 	public static final String MOCK_UP = "mockit.MockUp";
 	public static final String MOCK_CLASS = "mockit.MockClass";
 
+	public static final String CLASSINIT = "$clinit";
 	public static final String CTOR = "$init";
 	public static final String GET_INST = "getMockInstance";
+
+	/**
+	 * Tests if the method is a mock-method for (static) class initializers.
+	 * @param meth The mock-method to test. 
+	 * @return {@code true} if the method is a mock-method for (static) class initializers
+	 */
+	public static boolean isClassInitializerMock(final IMethodBinding meth)
+	{
+		return meth != null && meth.getName().equals(CLASSINIT);
+	}
 
 	public static boolean isMockMethod(final IMethodBinding meth)
 	{


### PR DESCRIPTION
Suggesting fix for Issue #23: Accept any $clinit() mock-method to prevent error-marker.